### PR TITLE
Bump up API version dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-sqladmin</artifactId>
-            <version>v1beta4-rev19-1.21.0</version>
+            <version>v1beta4-rev25-1.22.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This will pick up new version (1.22) of google-api-client which has improvements to reliability of retrieving credentials on GCE.