### PR TITLE
Add Postgres support for the Socket Factory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
 [![Build
 Status](https://travis-ci.org/GoogleCloudPlatform/cloud-sql-mysql-socket-factory.svg?branch=master)](https://travis-ci.org/GoogleCloudPlatform/cloud-sql-mysql-socket-factory)
-## Cloud SQL MySQL Socket Factory
+## Cloud SQL Socket Factory for JDBC drivers
 
-The Cloud SQL MySQL Socket Factory is a socket factory for the MySQL JDBC driver 
+The Cloud SQL Socket Factory is a library for the MySQL/Postgres JDBC drivers 
 that allows a user with the appropriate permissions to connect to a Cloud SQL 
 database without having to deal with IP whitelisting or SSL certificates 
 manually. 
 
-## Obtaining
+## Instructions
 
 The library is [available in Maven Central](http://search.maven.org/#artifactdetails%7Ccom.google.cloud.sql%7Cmysql-socket-factory%7C1.0.2%7Cjar).
 
 Add a dependency using your favorite build tool. Maven and Gradle examples are shown below.
 
+
+### MySQL
+
 **Note**: If you wish to use the 6.x (development) version of the MySQL driver, use the artifact id
 'mysql-socket-factory-connector-j-6'.
 
-### Maven
+#### Adding dependency (Maven)
 
 ```maven-pom
 <dependency>
@@ -26,26 +29,57 @@ Add a dependency using your favorite build tool. Maven and Gradle examples are s
 </dependency>
 ```
 
-### Gradle
+#### Adding dependency (Gradle)
 
 ```gradle
 compile 'com.google.cloud.sql:mysql-socket-factory:1.0.2'
 ```
 
-## Using
+#### Using
 
 When specifying the JDBC connection URL, add two additional parameters:
 
 | Property         | Value         |
 | ---------------- | ------------- |
-| cloudSqlInstance | The instance connection name (which is found on the instance details page in Google Developers Console)  |
 | socketFactory    | com.google.cloud.sql.mysql.SocketFactory |
+| cloudSqlInstance | The instance connection name (which is found on the instance details page in Google Developers Console)  |
 
 For example, if the instance connection name is `foo:bar:baz`, the JDBC URL 
 would be 
-`jdbc:mysql://google/mydb?cloudSqlInstance=foo:bar:baz&socketFactory=com.google.cloud.sql.mysql.SocketFactory`
+`jdbc:mysql://google/mydb?socketFactory=com.google.cloud.sql.mysql.SocketFactory&cloudSqlInstance=foo:bar:baz`
 
 A tool is available in `examples/getting-started` that can help you generate the right JDBC URL.
+
+### Postgres
+
+#### Adding dependency (Maven)
+
+```maven-pom
+<dependency>
+    <groupId>com.google.cloud.sql</groupId>
+    <artifactId>postgres-socket-factory</artifactId>
+    <version>1.0.3</version>
+</dependency>
+```
+
+#### Adding dependency (Gradle)
+
+```gradle
+compile 'com.google.cloud.sql:postgres-socket-factory:1.0.3'
+```
+
+#### Using
+
+When specifying the JDBC connection URL, add two additional parameters:
+
+| Property         | Value         |
+| ---------------- | ------------- |
+| socketFactory    | com.google.cloud.sql.postgres.SocketFactory |
+| socketFactoryArg | The instance connection name (which is found on the instance details page in Google Developers Console)  |
+
+For example, if the instance connection name is `foo:bar:baz`, the JDBC URL 
+would be 
+`jdbc:postgresql://google/mydb?socketFactory=com.google.cloud.sql.postgres.SocketFactory&socketFactoryArg=foo:bar:baz`
 
 ## Credentials
 

--- a/core/src/main/java/com/google/cloud/sql/mysql/SslSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/mysql/SslSocketFactory.java
@@ -71,7 +71,7 @@ import javax.xml.bind.DatatypeConverter;
  *
  * <p>The implementation is separate from {@link SocketFactory} to make this code easier to test.
  */
-class SslSocketFactory {
+public class SslSocketFactory {
   private static final Logger logger = Logger.getLogger(SslSocketFactory.class.getName());
 
   static final String ADMIN_API_NOT_ENABLED_REASON = "accessNotConfigured";
@@ -117,7 +117,7 @@ class SslSocketFactory {
     this.serverProxyPort = serverProxyPort;
   }
 
-  static synchronized SslSocketFactory getInstance() {
+  public static synchronized SslSocketFactory getInstance() {
     if (sslSocketFactory == null) {
       logger.info("First Cloud SQL connection, generating RSA key pair.");
       KeyPair keyPair = generateRsaKeyPair();
@@ -145,7 +145,7 @@ class SslSocketFactory {
   }
 
   // TODO(berezv): separate creating socket and performing connection to make it easier to test
-  Socket create(String instanceName) throws IOException {
+  public Socket create(String instanceName) throws IOException {
     try {
       return createAndConfigureSocket(instanceName, CertificateCaching.USE_CACHE);
     } catch (SSLHandshakeException e) {

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <module>core</module>
         <module>connector-j-5</module>
         <module>connector-j-6</module>
+        <module>postgres</module>
     </modules>
 
     <build>

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.google.cloud.sql</groupId>
+        <artifactId>mysql-socket-factory-parent</artifactId>
+        <version>1.0.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>postgres-socket-factory</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Cloud SQL Postgres Socket Factory</name>
+    <description>
+        Socket factory for the Postgres JDBC driver that allows a user with the appropriate
+        permissions to connect to a Cloud SQL database without having to deal with IP whitelisting
+        or SSL certificates manually
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.cloud.sql</groupId>
+            <artifactId>mysql-socket-factory-core</artifactId>
+            <version>1.0.3-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.sql.postgres;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.cloud.sql.mysql.SslSocketFactory;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.logging.Logger;
+
+/**
+ * A Postgres {@link SocketFactory} that establishes a secure connection to a Cloud SQL instance
+ * using ephemeral certificates.
+ *
+ * <p>The heavy lifting is done by the singleton {@link SslSocketFactory} class.
+ */
+public class SocketFactory extends javax.net.SocketFactory {
+  private static final Logger logger = Logger.getLogger(SocketFactory.class.getName());
+
+  private final String instanceName;
+
+  public SocketFactory(String instanceName) {
+    checkArgument(
+        instanceName != null,
+        "socketFactoryArg property not set. Please specify this property in the JDBC "
+            + "URL or the connection Properties with the instance connection name in "
+            + "form \"project:region:instance\"");
+    this.instanceName = instanceName;
+  }
+
+  @Override
+  public Socket createSocket() throws IOException {
+    logger.info(String.format("Connecting to Cloud SQL instance [%s].", instanceName));
+    return SslSocketFactory.getInstance().create(instanceName);
+  }
+
+  @Override
+  public Socket createSocket(String host, int port) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress host, int port) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort)
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+}


### PR DESCRIPTION
The core code in SslSocketFactory is reused as is.

The main difference between the MySQL implementation and the Postgres
implementation is that the user has to specify the instance name via the
`socketFactoryArg` property instead of a custom property as the Postgres
socket factory does not have access to the params.

There needs to be some cleanup in the code to move the common code out
of the 'mysql' package, but I'll leave it to a separate CL to keep this
small.

We also need to consider moving this code to a more 'generic' repo as
this one is mysql-specific, but that's a larger unertaking left to a
separate exercise.