### PR TITLE
Naming cleanup:

### DIFF
--- a/connector-j-5/pom.xml
+++ b/connector-j-5/pom.xml
@@ -4,7 +4,7 @@
 
     <parent>
         <groupId>com.google.cloud.sql</groupId>
-        <artifactId>mysql-socket-factory-parent</artifactId>
+        <artifactId>jdbc-socket-factory-parent</artifactId>
         <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-socket-factory</artifactId>
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>com.google.cloud.sql</groupId>
-            <artifactId>mysql-socket-factory-core</artifactId>
+            <artifactId>jdbc-socket-factory-core</artifactId>
             <version>1.0.4-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-5/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -18,6 +18,7 @@ package com.google.cloud.sql.mysql;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.cloud.sql.core.SslSocketFactory;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.Properties;

--- a/connector-j-6/pom.xml
+++ b/connector-j-6/pom.xml
@@ -4,7 +4,7 @@
 
     <parent>
         <groupId>com.google.cloud.sql</groupId>
-        <artifactId>mysql-socket-factory-parent</artifactId>
+        <artifactId>jdbc-socket-factory-parent</artifactId>
         <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-socket-factory-connector-j-6</artifactId>
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>com.google.cloud.sql</groupId>
-            <artifactId>mysql-socket-factory-core</artifactId>
+            <artifactId>jdbc-socket-factory-core</artifactId>
             <version>1.0.4-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
+++ b/connector-j-6/src/main/java/com/google/cloud/sql/mysql/SocketFactory.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.sql.mysql;
 
+import com.google.cloud.sql.core.SslSocketFactory;
 import java.io.IOException;
 import java.net.Socket;
 import java.util.Properties;

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,10 +4,10 @@
 
     <parent>
         <groupId>com.google.cloud.sql</groupId>
-        <artifactId>mysql-socket-factory-parent</artifactId>
+        <artifactId>jdbc-socket-factory-parent</artifactId>
         <version>1.0.4-SNAPSHOT</version>
     </parent>
-    <artifactId>mysql-socket-factory-core</artifactId>
+    <artifactId>jdbc-socket-factory-core</artifactId>
     <packaging>jar</packaging>
 
     <name>Cloud SQL MySQL Socket Factory (Core Library, don't depend on this directly)</name>

--- a/core/src/main/java/com/google/cloud/sql/core/CredentialFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/CredentialFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.sql.mysql;
+package com.google.cloud.sql.core;
 
 import com.google.api.client.auth.oauth2.Credential;
 

--- a/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
+++ b/core/src/main/java/com/google/cloud/sql/core/SslSocketFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.sql.mysql;
+package com.google.cloud.sql.core;
 
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;

--- a/core/src/test/java/com/google/cloud/sql/core/SslSocketFactoryTest.java
+++ b/core/src/test/java/com/google/cloud/sql/core/SslSocketFactoryTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.sql.mysql;
+package com.google.cloud.sql.core;
 
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -38,7 +38,7 @@ import com.google.api.services.sqladmin.model.DatabaseInstance;
 import com.google.api.services.sqladmin.model.IpMapping;
 import com.google.api.services.sqladmin.model.SslCert;
 import com.google.api.services.sqladmin.model.SslCertsCreateEphemeralRequest;
-import com.google.cloud.sql.mysql.SslSocketFactory.Clock;
+import com.google.cloud.sql.core.SslSocketFactory.Clock;
 import com.google.common.collect.ImmutableList;
 
 import org.joda.time.DateTime;

--- a/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
+++ b/core/src/test/java/com/google/cloud/sql/core/TestKeys.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.google.cloud.sql.mysql;
+package com.google.cloud.sql.core;
 
 class TestKeys {
   static final String SIGNING_CA_PRIVATE_KEY =

--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.google.cloud.sql</groupId>
-    <artifactId>mysql-socket-factory-parent</artifactId>
+    <artifactId>jdbc-socket-factory-parent</artifactId>
     <packaging>pom</packaging>
     <version>1.0.4-SNAPSHOT</version>
 
-    <name>Cloud SQL MySQL Socket Factory</name>
+    <name>Cloud SQL JDBC Socket Factory</name>
     <description>
-        Socket factory for the MySQL JDBC driver that allows a user with the appropriate permissions
-        to connect to a Cloud SQL database without having to deal with IP whitelisting or SSL
-        certificates manually
+        Socket factories for MySQL/Postgres JDBC drivers that allows a user with the appropriate
+        permissions to connect to a Cloud SQL database without having to deal with IP whitelisting
+        or SSL certificates manually
     </description>
     <url>https://github.com/GoogleCloudPlatform/cloud-sql-mysql-socket-factory</url>
 

--- a/postgres/pom.xml
+++ b/postgres/pom.xml
@@ -4,7 +4,7 @@
 
     <parent>
         <groupId>com.google.cloud.sql</groupId>
-        <artifactId>mysql-socket-factory-parent</artifactId>
+        <artifactId>jdbc-socket-factory-parent</artifactId>
         <version>1.0.4-SNAPSHOT</version>
     </parent>
     <artifactId>postgres-socket-factory</artifactId>
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>com.google.cloud.sql</groupId>
-            <artifactId>mysql-socket-factory-core</artifactId>
+            <artifactId>jdbc-socket-factory-core</artifactId>
             <version>1.0.4-SNAPSHOT</version>
         </dependency>
     </dependencies>

--- a/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
+++ b/postgres/src/main/java/com/google/cloud/sql/postgres/SocketFactory.java
@@ -18,7 +18,7 @@ package com.google.cloud.sql.postgres;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.cloud.sql.mysql.SslSocketFactory;
+import com.google.cloud.sql.core.SslSocketFactory;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;


### PR DESCRIPTION
 - Move the 'core' classes from 'mysql' Java package to 'core' package.
 - Change 'mysql-socket-factory' to 'jdbc-socket-factory' in non-mysql
   specific artifact IDs.